### PR TITLE
Update HTML templates to use hidden CSRF token fields

### DIFF
--- a/habit_tracker/app/templates/dashboard.html
+++ b/habit_tracker/app/templates/dashboard.html
@@ -29,14 +29,14 @@
             <div class="habit-item">
                 <!-- Habit checkbox and label -->
                 <form action="{{ url_for('main.toggle_habit', habit_id=habit.id) }}" method="POST" class="toggle-form">
-                    {{ csrf_token() }}
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <input type="checkbox" id="habit{{ habit.id }}" {% if habit.completed %}checked{% endif %} onchange="this.form.submit()">
                     <label for="habit{{ habit.id }}">{{ habit.name }}</label>
                 </form>
                 
                 <!-- Delete habit button -->
                 <form action="{{ url_for('main.delete_habit', habit_id=habit.id) }}" method="POST" style="display:inline;">
-                    {{ csrf_token() }}
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <button type="submit" class="delete-btn" onclick="return confirm('Are you sure you want to delete this habit?');">
                         <i class="fas fa-trash"></i>
                     </button>
@@ -46,7 +46,7 @@
             </div>
             <!-- Add new habit form -->
             <form action="{{ url_for('main.create_habit') }}" method="POST" class="add-habit-form" style="display: flex; justify-content: space-between; align-items: center;">
-                {{ csrf_token() }}
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <input id="input-field" type="text" name="habit_name" placeholder="New habit name" required style="flex: 1; margin-right: 10px;">
                 <button type="submit" class="add-habit-btn">add</button>
             </form>

--- a/habit_tracker/app/templates/index.html
+++ b/habit_tracker/app/templates/index.html
@@ -28,7 +28,7 @@
       <div class="form-content">
         <button class="close-btn form-btn" onclick="closeLoginForm()">×</button>
         <form method="POST" action="{{ url_for('auth.login') }}">
-          {{ csrf_token() }}
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
           <label>Username:</label>
           <input type="text" name="username" required>
           <label>Password:</label>
@@ -64,7 +64,7 @@
           <div class="form-content">
             <button class="close-btn form-btn" onclick="closeSignupForm()">×</button>
             <form method="POST" action="{{ url_for('auth.signup') }}">
-              {{ csrf_token() }}
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
               <label>Username:</label>
               <input type="text" name="username" required>
               <label>Email:</label>

--- a/habit_tracker/app/templates/profile.html
+++ b/habit_tracker/app/templates/profile.html
@@ -41,7 +41,7 @@
 
         <section class="profile-container">
             <form action="/update_username" method="POST">
-                {{ csrf_token() }}
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <label for="new-username">New Username:</label>
                 <input type="text" id="new-username" name="new_username" required>
                 <button type="submit">Update Username</button>
@@ -56,7 +56,7 @@
                 {% endwith %}
             </form>
             <form action="/update_email" method="POST">
-                {{ csrf_token() }}
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <label for="new-email">New Email:</label>
                 <input type="email" id="new-email" name="new_email" required>
                 <button type="submit">Update Email</button>
@@ -73,7 +73,7 @@
 
             </form>
             <form action="/update_password" method="POST">
-                {{ csrf_token() }}
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <label for="current-password">Current Password:</label>
                 <input type="password" id="current-password" name="current_password" required>
                 <label for="new-password">New Password:</label>


### PR DESCRIPTION
- Replace direct {{ csrf_token() }} output with <input type="hidden" name="csrf_token" value="{{ csrf_token() }}> in all POST forms.

- Ensure CSRF tokens are not visibly rendered on the page, but are securely included in form submissions.

- Confirm that weekly.html and yearly.html do not require CSRF tokens as they contain no forms.

- Improve overall security and user experience for all authentication and data modification forms.