### PR TITLE
fix: add missing Request import for Gmail API refresh

### DIFF
--- a/habit_tracker/app/gmail_api.py
+++ b/habit_tracker/app/gmail_api.py
@@ -4,6 +4,7 @@ from email.mime.text import MIMEText
 from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
+from google.auth.transport.requests import Request
 
 SCOPES = ['https://www.googleapis.com/auth/gmail.send']
 


### PR DESCRIPTION
- Add import statement for Request from google.auth.transport.requests
- Fix NameError in get_gmail_service function
- Ensure proper token refresh functionality for Gmail API authentication