### PR TITLE
Bug fixed: Synchronize legend 'Completed' color with grid color in yearly view

### DIFF
--- a/habit_tracker/app/static/css/style.css
+++ b/habit_tracker/app/static/css/style.css
@@ -237,3 +237,9 @@ footer p {
   margin-top: 0.5em;
   letter-spacing: 0.1em;
 }
+
+.signup-btn {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/habit_tracker/app/static/css/yearly.css
+++ b/habit_tracker/app/static/css/yearly.css
@@ -166,10 +166,6 @@
     background-color: #ebedf0;
 }
 
-.legend-cell.completed {
-    background-color: #239a3b;
-}
-
 #yearSelect {
     font-size: 1.1rem;
     padding: 6px 0 6px 0;

--- a/habit_tracker/app/static/js/yearly.js
+++ b/habit_tracker/app/static/js/yearly.js
@@ -230,6 +230,19 @@ document.addEventListener('DOMContentLoaded', function() {
         const currentYear = new Date().getFullYear();
         initializeGrids(currentYear);
     });
+
+    // Dynamic sync legend color
+    const habitContainers = document.querySelectorAll('.habit-container');
+    const colors = window.habitChartColors || ['#4caf50', '#2196f3', '#ff9800', '#e91e63', '#9c27b0'];
+    habitContainers.forEach((container, index) => {
+        const legend = container.querySelector('.intensity-legend');
+        if (legend) {
+            const completedSpan = legend.querySelector('.completed-color');
+            if (completedSpan) {
+                completedSpan.style.background = colors[index % colors.length];
+            }
+        }
+    });
 });
 
 function initYearSelector() {

--- a/habit_tracker/app/templates/yearly.html
+++ b/habit_tracker/app/templates/yearly.html
@@ -15,17 +15,15 @@
                 <h3 class="habit-title">{{ habit.habit_name }}</h3>
             </div>
             <div class="yearly-grid-scroll">
-                <div class="github-style-grid" id="grid-{{ habit.id }}">
-                    <!-- JS 动态生成的网格 -->
-                </div>
+                <div class="github-style-grid" id="grid-{{ habit.id }}"></div>
             </div>
             <div class="grid-footer">
                 <div></div>
-                <div class="intensity-legend">
+                <div class="intensity-legend" id="legend-{{ habit.id }}">
                     <span class="legend-label">Not Completed</span>
                     <div class="legend-cell not-completed"></div>
                     <span class="legend-label">Completed</span>
-                    <div class="legend-cell completed"></div>
+                    <div class="legend-cell completed completed-color"></div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This PR improves the visual consistency of the yearly habit tracker view by ensuring that the legend’s “Completed” color matches the actual color used for completed days in the grid for each habit.
<img width="962" alt="Screenshot 2025-05-15 at 14 58 03" src="https://github.com/user-attachments/assets/acb598b3-d690-4900-ad67-f66cfbb54737" />
